### PR TITLE
fix: Initialize fluentd as nil

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -60,7 +61,7 @@ func (f *Function) RunFunction(ctx context.Context, req *fnv1beta1.RunFunctionRe
 
 	projectid, ok := targetns.GetLabels()[in.NamespaceLabel]
 	if !ok {
-		response.Fatal(rsp, errors.New("cannot get project id"))
+		response.Fatal(rsp, fmt.Errorf("cannot get project id %s for namespace %s", projectid, targetns.GetName()))
 		return rsp, nil
 	}
 

--- a/fn.go
+++ b/fn.go
@@ -69,7 +69,6 @@ func (f *Function) RunFunction(ctx context.Context, req *fnv1beta1.RunFunctionRe
 	l.Spec.ControlNamespace = ns
 	l.Spec.WatchNamespaceSelector = &metav1.LabelSelector{}
 	l.Spec.WatchNamespaceSelector.MatchLabels = map[string]string{in.NamespaceLabel: projectid}
-	l.Spec.FluentdSpec = nil
 
 	cd, err := composed.From(l)
 	if err != nil {

--- a/fn.go
+++ b/fn.go
@@ -68,7 +68,7 @@ func (f *Function) RunFunction(ctx context.Context, req *fnv1beta1.RunFunctionRe
 	l.Spec.ControlNamespace = ns
 	l.Spec.WatchNamespaceSelector = &metav1.LabelSelector{}
 	l.Spec.WatchNamespaceSelector.MatchLabels = map[string]string{in.NamespaceLabel: projectid}
-	l.Spec.FluentdSpec = &v1beta1.FluentdSpec{}
+	l.Spec.FluentdSpec = nil
 
 	cd, err := composed.From(l)
 	if err != nil {

--- a/fn_test.go
+++ b/fn_test.go
@@ -86,29 +86,6 @@ func TestRunFunction(t *testing.T) {
 										},
 										"enableRecreateWorkloadOnImmutableFieldChange": false,
 										"flowConfigCheckDisabled": false,
-										"fluentd": {
-											"compressConfigFile": false,
-											"disablePvc": false,
-											"enableMsgpackTimeSupport": false,
-											"livenessDefaultCheck": false,
-											"port": 0,
-											"readinessDefaultCheck": {
-												"bufferFileNumber": false,
-												"bufferFileNumberMax": 0,
-												"bufferFreeSpace": false,
-												"bufferFreeSpaceThreshold": 0,
-												"failureThreshold":         0,
-												"initialDelaySeconds":      0,
-												"periodSeconds":            0,
-												"successThreshold":         0,
-												"timeoutSeconds":           0
-											},
-											"tls": {
-												"enabled": false
-											},
-											"volumeMountChmod":      false,
-											"workers":               0
-										},
 										"skipInvalidResources": false
 									},
 									"status": {


### PR DESCRIPTION
# Changes

Initializes `fluentdSpec` as nil, so a user can configure their fluentd through the FluentdConfig CRD.
This is needed so creating a new `logging.caas.telekom.de` resource does not initialize the fluentd object in the `logging.banzaicloud.io` resource. By setting it to nil, a user can override the config from the FluentdConfig CRD, which otherwise would not work correctly